### PR TITLE
Add documentation for Saramito model

### DIFF
--- a/docs/_sources/material_file/mechanical_and_constitutive.rst.txt
+++ b/docs/_sources/material_file/mechanical_and_constitutive.rst.txt
@@ -89,6 +89,8 @@ momentum conservation equations.
 
 .. include:: mechanical_and_constitutive/polymer_time_constant.rst
 
+.. include:: mechanical_and_constitutive/polymer_yield_stress.rst
+
 .. include:: mechanical_and_constitutive/mobility_parameter.rst
 
 .. include:: mechanical_and_constitutive/ptt_xi_parameter.rst

--- a/docs/_sources/material_file/mechanical_and_constitutive/polymer_constitutive_equation.rst.txt
+++ b/docs/_sources/material_file/mechanical_and_constitutive/polymer_constitutive_equation.rst.txt
@@ -15,25 +15,34 @@ parameter must be defined, that being the {model_name}.
 
 +-----------------+------------------------------------------------------------------------------------------------------------+
 |{model_name}     |Name of the constitutive equation model, being one of the following values: **NOPOLYMER, OLDROYDB, GIESEKUS,|
-|                 |PTT, WHITE-METZNER**. Several of these polymer constitutive models require additional parameters for the    |
-|                 |polymer properties that are entered via additional cards, as described below. Please see the Example section|
-|                 |and the tutorial referenced below.                                                                          |
+|                 |PTT, SARAMITO_OLDROYDB, SARAMITO_GIESEKUS, SARAMITO_PTT, WHITE-METZNER**. Several of these polymer          |
+|                 |constitutive models require additional parameters for the polymer properties that are entered via           |
+|                 |additional cards, as described below. Please see the Example sectionand the tutorial referenced below.      |
 +-----------------+------------------------------------------------------------------------------------------------------------+
 
 Thus,
 
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**NOPOLYMER**    |For Newtonian and generalized Newtonian models. No floating point values are required.                      |
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**OLDROYDB**     |For the Oldroyd-B constitutive model. This option requires four floating point values, which are described  |
-|                 |below.                                                                                                      |
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**GIESEKUS**     |For the Giesekus model. This option requires five floating point values, which are described below.         |
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**PTT**          |For the Phan-Thien Tanner model. This option requires six floating point values, which are described below. |
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**WHITE_METZNER**|For the White-Metzner model. This option is not currently working.                                          |
-+-----------------+------------------------------------------------------------------------------------------------------------+
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**NOPOLYMER**        |For Newtonian and generalized Newtonian models. No floating point values are required.                      |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**OLDROYDB**         |For the Oldroyd-B constitutive model. This option requires four floating point values, which are described  |
+|                     |below.                                                                                                      |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**GIESEKUS**         |For the Giesekus model. This option requires five floating point values, which are described below.         |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**PTT**              |For the Phan-Thien Tanner model. This option requires six floating point values, which are described below. |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**SARAMITO_OLDROYDB**|For the Oldroyd-B model used with the Saramito yield model. This option requires six floating point values, |
+|                     |which are described below.                                                                                  |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**SARAMITO_GIESEKUS**|For the Giesekus model used with the Saramito yield model. This option requires seven floating point values,| 
+|                     |which are described below.                                                                                  |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**SARAMITO_PTT**     |For the Giesekus model used with the Saramito yield model. This option requires eight floating point values,|
+|                     |which are described below.                                                                                  |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**WHITE_METZNER**    |For the White-Metzner model. This option is not currently working.                                          |
++---------------------+------------------------------------------------------------------------------------------------------------+
 
 ------------
 **Examples**
@@ -123,6 +132,117 @@ constant and nonlinear PTT parameters.:
 ::
 
    Polymer Time Constant = CONSTANT 0.01
+
+::
+
+   PTT Xi parameter = CONSTANT 0.10
+
+::
+
+   PTT Epsilon parameter = CONSTANT 0.05
+
+The following is a sample card that sets the polymer constitutive equation to
+**SARAMITO_OLDROYDB**. This option requires six cards describing the polymer
+stress formulation, weight function, viscosity, time constant, yield stress, 
+and yield exponent.
+
+::
+
+   Polymer Constitutive Equation = OLDROYDB
+
+::
+
+   Polymer Stress Formulation = EVSS_F
+
+::
+
+   Polymer Weight Function = GALERKIN
+
+::
+
+   Polymer Viscosity = CONSTANT 1.
+
+::
+
+   Polymer Time Constant = CONSTANT 0.02
+
+::
+
+  Polymer Yield Stress = CONSTANT 15.
+
+::
+
+  Yield Exponent = CONSTANT 0.
+
+The following is a sample card that sets the polymer constitutive equation to
+**SARAMITO_GIESEKUS**. This option requires seven cards describing the polymer stress
+formulation, weight function, viscosity, time constant, mobility parameter, yield 
+stress, and yield exponent.
+
+::
+
+   Polymer Constitutive Equation = GIESEKUS
+
+::
+
+   Polymer Stress Formulation = EVSS_F
+
+::
+
+   Polymer Weight Function = GALERKIN
+
+::
+
+   Polymer Viscosity = CONSTANT 1.
+
+::
+
+   Polymer Time Constant = CONSTANT 0.2
+
+::
+
+  Polymer Yield Stress = CONSTANT 12.
+
+::
+
+  Yield Exponent = CONSTANT 1.0
+
+::
+
+   Mobility Parameter = CONSTANT 0.1
+
+The following is a sample card that sets the polymer constitutive equation to 
+**SARAMITO_PTT**. This option requires eight additional cards that set the
+polymer stress formulation, weight function for the stress equation, viscosity, time
+constant, nonlinear PTT parameters, yield stress, and yield exponent.
+
+::
+
+   Polymer Consitutive Equation = PTT
+
+::
+
+   Polymer Stress Formulation = EVSS_F
+
+::
+
+   Polymer Weight Function = GALERKIN
+
+::
+
+   Polymer Viscosity = CONSTANT 8000.
+
+::
+
+   Polymer Time Constant = CONSTANT 0.01
+
+::
+
+  Polymer Yield Stress = CONSTANT 200.
+
+::
+
+  Yield Exponent = CONSTANT 0.5
 
 ::
 

--- a/docs/_sources/material_file/mechanical_and_constitutive/polymer_yield_stress.rst.txt
+++ b/docs/_sources/material_file/mechanical_and_constitutive/polymer_yield_stress.rst.txt
@@ -1,0 +1,43 @@
+************************
+**Polymer Yield Stress**
+************************
+
+::
+
+   Polymer Yield Stress = CONSTANT <float> []
+
+-----------------------
+**Description / Usage**
+-----------------------
+
+This card is required when using the Saramito yield model. The card should be included in the input when
+the option selected for the *Polymer Constitutive Equation* card is **SARAMITO_OLDROYDB**, **SARAMITO_GIESEKUS**,
+or **SARAMITO_PTT**. Definitions of the input parameters are as follows:
+
++-----------------+------------------------------------------------------------------------------------------------------------+
+|**CONSTANT**     |Name of the model for the yield stress.                                                                     |
+|                 |                                                                                                            |
+|                 | * <float> - the value of the yield stress.                                                                 |
++-----------------+------------------------------------------------------------------------------------------------------------+
+
+This card does not have to be present for constitutive equations other than
+**SARAMITO_OLDROYDB**, **SARAMITO_GIESEKUS**, and **SARAMITO_PTT**
+
+------------
+**Examples**
+------------
+
+The following is a sample card that sets the polymer yield stress to 12:
+
+::
+
+   Polymer Yield Stress = CONSTANT 12
+
+-------------------------
+**Technical Discussion**
+-------------------------
+
+No Discussion.
+
+
+

--- a/docs/_sources/material_file/mechanical_and_constitutive/yield_exponent.rst.txt
+++ b/docs/_sources/material_file/mechanical_and_constitutive/yield_exponent.rst.txt
@@ -11,19 +11,25 @@ Yield Exponent
 -----------------------
 
 This card is used to specify the model for the yield exponent parameter, *F*, for the
-**BINGHAM** model option of the *Liquid Constitutive Equation* card. Definitions of the
-input parameters are as follows:
+**BINGHAM** model option of the *Liquid Constitutive Equation* card, or when the 
+*Polymer Constitutive Equation* card is **SARAMITO_OLDROYDB**, **SARAMITO_GIESEKUS**,
+or **SARAMITO_PTT**. Definitions of the input parameters are as follows:
 
 +-----------------+------------------------------------------------------------------------------------------------------------+
-|**CONSTANT**     |Name of the model for the yield stress.                                                                     |
+|**CONSTANT**     |Name of the model for the yield exponent.                                                                   |
 |                 |                                                                                                            |
 |                 | * <float> - the value of the yield exponent, *F*, which has the dimensions of inverse shear-rate in        |
 |                 |   whatever units are consistent with the problem of interest and which connotes the steepness of the       |
-|                 |   transition from solid to fluid behavior for the Bingham-Carreau-Yasudamodel.                             |
+|                 |   transition from solid to fluid behavior for the Bingham-Carreau-Yasuda model or the Saramito yield       |
+|                 |   stress model.                                                                                            |
 +-----------------+------------------------------------------------------------------------------------------------------------+
 
-If *F* is large, the material has an abrupt transition from solid-like to fluid-like behavior,
-whereas for a small *F*, the transition is more gradual.
+For the **BINGHAM** model, if *F* is large, the material has an abrupt transition from solid-like to 
+fluid-like behavior, whereas for a small *F*, the transition is more gradual.
+
+For the **SARAMITO_OLDROYDB**, **SARAMITO_GIESEKUS**, and **SARAMITO_PTT** models, the material has
+and abrupt transition when *F* equals zero. This Transistion becomes smooth for nonzero when *F* 
+is greater than zero, with the transition becoming more gradual as *F* increases.
 
 ------------
 **Examples**

--- a/material_file/mechanical_and_constitutive.rst
+++ b/material_file/mechanical_and_constitutive.rst
@@ -89,6 +89,8 @@ momentum conservation equations.
 
 .. include:: mechanical_and_constitutive/polymer_time_constant.rst
 
+.. include:: mechanical_and_constitutive/polymer_yield_stress.rst
+
 .. include:: mechanical_and_constitutive/mobility_parameter.rst
 
 .. include:: mechanical_and_constitutive/ptt_xi_parameter.rst

--- a/material_file/mechanical_and_constitutive/polymer_constitutive_equation.rst
+++ b/material_file/mechanical_and_constitutive/polymer_constitutive_equation.rst
@@ -15,25 +15,34 @@ parameter must be defined, that being the {model_name}.
 
 +-----------------+------------------------------------------------------------------------------------------------------------+
 |{model_name}     |Name of the constitutive equation model, being one of the following values: **NOPOLYMER, OLDROYDB, GIESEKUS,|
-|                 |PTT, WHITE-METZNER**. Several of these polymer constitutive models require additional parameters for the    |
-|                 |polymer properties that are entered via additional cards, as described below. Please see the Example section|
-|                 |and the tutorial referenced below.                                                                          |
+|                 |PTT, SARAMITO_OLDROYDB, SARAMITO_GIESEKUS, SARAMITO_PTT, WHITE-METZNER**. Several of these polymer          |
+|                 |constitutive models require additional parameters for the polymer properties that are entered via           |
+|                 |additional cards, as described below. Please see the Example sectionand the tutorial referenced below.      |
 +-----------------+------------------------------------------------------------------------------------------------------------+
 
 Thus,
 
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**NOPOLYMER**    |For Newtonian and generalized Newtonian models. No floating point values are required.                      |
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**OLDROYDB**     |For the Oldroyd-B constitutive model. This option requires four floating point values, which are described  |
-|                 |below.                                                                                                      |
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**GIESEKUS**     |For the Giesekus model. This option requires five floating point values, which are described below.         |
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**PTT**          |For the Phan-Thien Tanner model. This option requires six floating point values, which are described below. |
-+-----------------+------------------------------------------------------------------------------------------------------------+
-|**WHITE_METZNER**|For the White-Metzner model. This option is not currently working.                                          |
-+-----------------+------------------------------------------------------------------------------------------------------------+
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**NOPOLYMER**        |For Newtonian and generalized Newtonian models. No floating point values are required.                      |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**OLDROYDB**         |For the Oldroyd-B constitutive model. This option requires four floating point values, which are described  |
+|                     |below.                                                                                                      |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**GIESEKUS**         |For the Giesekus model. This option requires five floating point values, which are described below.         |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**PTT**              |For the Phan-Thien Tanner model. This option requires six floating point values, which are described below. |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**SARAMITO_OLDROYDB**|For the Oldroyd-B model used with the Saramito yield model. This option requires six floating point values, |
+|                     |which are described below.                                                                                  |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**SARAMITO_GIESEKUS**|For the Giesekus model used with the Saramito yield model. This option requires seven floating point values,| 
+|                     |which are described below.                                                                                  |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**SARAMITO_PTT**     |For the Giesekus model used with the Saramito yield model. This option requires eight floating point values,|
+|                     |which are described below.                                                                                  |
++---------------------+------------------------------------------------------------------------------------------------------------+
+|**WHITE_METZNER**    |For the White-Metzner model. This option is not currently working.                                          |
++---------------------+------------------------------------------------------------------------------------------------------------+
 
 ------------
 **Examples**
@@ -123,6 +132,117 @@ constant and nonlinear PTT parameters.:
 ::
 
    Polymer Time Constant = CONSTANT 0.01
+
+::
+
+   PTT Xi parameter = CONSTANT 0.10
+
+::
+
+   PTT Epsilon parameter = CONSTANT 0.05
+
+The following is a sample card that sets the polymer constitutive equation to
+**SARAMITO_OLDROYDB**. This option requires six cards describing the polymer
+stress formulation, weight function, viscosity, time constant, yield stress, 
+and yield exponent.
+
+::
+
+   Polymer Constitutive Equation = OLDROYDB
+
+::
+
+   Polymer Stress Formulation = EVSS_F
+
+::
+
+   Polymer Weight Function = GALERKIN
+
+::
+
+   Polymer Viscosity = CONSTANT 1.
+
+::
+
+   Polymer Time Constant = CONSTANT 0.02
+
+::
+
+  Polymer Yield Stress = CONSTANT 15.
+
+::
+
+  Yield Exponent = CONSTANT 0.
+
+The following is a sample card that sets the polymer constitutive equation to
+**SARAMITO_GIESEKUS**. This option requires seven cards describing the polymer stress
+formulation, weight function, viscosity, time constant, mobility parameter, yield 
+stress, and yield exponent.
+
+::
+
+   Polymer Constitutive Equation = GIESEKUS
+
+::
+
+   Polymer Stress Formulation = EVSS_F
+
+::
+
+   Polymer Weight Function = GALERKIN
+
+::
+
+   Polymer Viscosity = CONSTANT 1.
+
+::
+
+   Polymer Time Constant = CONSTANT 0.2
+
+::
+
+  Polymer Yield Stress = CONSTANT 12.
+
+::
+
+  Yield Exponent = CONSTANT 1.0
+
+::
+
+   Mobility Parameter = CONSTANT 0.1
+
+The following is a sample card that sets the polymer constitutive equation to 
+**SARAMITO_PTT**. This option requires eight additional cards that set the
+polymer stress formulation, weight function for the stress equation, viscosity, time
+constant, nonlinear PTT parameters, yield stress, and yield exponent.
+
+::
+
+   Polymer Consitutive Equation = PTT
+
+::
+
+   Polymer Stress Formulation = EVSS_F
+
+::
+
+   Polymer Weight Function = GALERKIN
+
+::
+
+   Polymer Viscosity = CONSTANT 8000.
+
+::
+
+   Polymer Time Constant = CONSTANT 0.01
+
+::
+
+  Polymer Yield Stress = CONSTANT 200.
+
+::
+
+  Yield Exponent = CONSTANT 0.5
 
 ::
 

--- a/material_file/mechanical_and_constitutive/polymer_yield_stress.rst
+++ b/material_file/mechanical_and_constitutive/polymer_yield_stress.rst
@@ -1,0 +1,43 @@
+************************
+**Polymer Yield Stress**
+************************
+
+::
+
+   Polymer Yield Stress = CONSTANT <float> []
+
+-----------------------
+**Description / Usage**
+-----------------------
+
+This card is required when using the Saramito yield model. The card should be included in the input when
+the option selected for the *Polymer Constitutive Equation* card is **SARAMITO_OLDROYDB**, **SARAMITO_GIESEKUS**,
+or **SARAMITO_PTT**. Definitions of the input parameters are as follows:
+
++-----------------+------------------------------------------------------------------------------------------------------------+
+|**CONSTANT**     |Name of the model for the yield stress.                                                                     |
+|                 |                                                                                                            |
+|                 | * <float> - the value of the yield stress.                                                                 |
++-----------------+------------------------------------------------------------------------------------------------------------+
+
+This card does not have to be present for constitutive equations other than
+**SARAMITO_OLDROYDB**, **SARAMITO_GIESEKUS**, and **SARAMITO_PTT**
+
+------------
+**Examples**
+------------
+
+The following is a sample card that sets the polymer yield stress to 12:
+
+::
+
+   Polymer Yield Stress = CONSTANT 12
+
+-------------------------
+**Technical Discussion**
+-------------------------
+
+No Discussion.
+
+
+

--- a/material_file/mechanical_and_constitutive/yield_exponent.rst
+++ b/material_file/mechanical_and_constitutive/yield_exponent.rst
@@ -11,19 +11,25 @@ Yield Exponent
 -----------------------
 
 This card is used to specify the model for the yield exponent parameter, *F*, for the
-**BINGHAM** model option of the *Liquid Constitutive Equation* card. Definitions of the
-input parameters are as follows:
+**BINGHAM** model option of the *Liquid Constitutive Equation* card, or when the 
+*Polymer Constitutive Equation* card is **SARAMITO_OLDROYDB**, **SARAMITO_GIESEKUS**,
+or **SARAMITO_PTT**. Definitions of the input parameters are as follows:
 
 +-----------------+------------------------------------------------------------------------------------------------------------+
-|**CONSTANT**     |Name of the model for the yield stress.                                                                     |
+|**CONSTANT**     |Name of the model for the yield exponent.                                                                   |
 |                 |                                                                                                            |
 |                 | * <float> - the value of the yield exponent, *F*, which has the dimensions of inverse shear-rate in        |
 |                 |   whatever units are consistent with the problem of interest and which connotes the steepness of the       |
-|                 |   transition from solid to fluid behavior for the Bingham-Carreau-Yasudamodel.                             |
+|                 |   transition from solid to fluid behavior for the Bingham-Carreau-Yasuda model or the Saramito yield       |
+|                 |   stress model.                                                                                            |
 +-----------------+------------------------------------------------------------------------------------------------------------+
 
-If *F* is large, the material has an abrupt transition from solid-like to fluid-like behavior,
-whereas for a small *F*, the transition is more gradual.
+For the **BINGHAM** model, if *F* is large, the material has an abrupt transition from solid-like to 
+fluid-like behavior, whereas for a small *F*, the transition is more gradual.
+
+For the **SARAMITO_OLDROYDB**, **SARAMITO_GIESEKUS**, and **SARAMITO_PTT** models, the material has
+and abrupt transition when *F* equals zero. This Transistion becomes smooth for nonzero when *F* 
+is greater than zero, with the transition becoming more gradual as *F* increases.
 
 ------------
 **Examples**
@@ -39,7 +45,7 @@ The following is a sample card that sets the yield exponent to 10.0
 **Technical Discussion**
 -------------------------
 
-See Description/Usage for *Liquid Constitutive Equation* card.
+See Description/Usage for *Liquid Constitutive Equation* and *Polymer Constitutive Equation* cards.
 
 
 


### PR DESCRIPTION
This merge request adds documentation pertaining to Saramito model. This includes sample cards for polymer constitutive equations used with the Saramito model (SARAMITO_OLDROYDB, etc.)